### PR TITLE
Fix permission check on billing settings tab bar item

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -22,6 +22,7 @@ The resources that workspace users can work on are the following:
 - Task label
 - Sub task
 - Chat message
+- Customer
 
 The following actions are possible on each resource, modelled after a typical
 CRUD application:
@@ -48,6 +49,7 @@ role required to perform that action.
 | Task label              | Member     | Observer   | Member     | Member     |
 | Sub task                | Member     | Observer   | Member     | Member     |
 | Chat message            | Member     | Observer   | Member     | Maintainer |
+| Customer                | Owner      | Owner      | Owner      | Owner      |
 
 ## Role descriptions
 
@@ -110,6 +112,7 @@ workspace maintenance.
 - Create, read, update and delete workspace user invites, that is, invite new
   workspace users
 - Create, update and delete workspace users
+- Create, read, update and delete customer
 
 ## Rule implementation
 

--- a/frontend/src/lib/figma/screens/workspace-settings/TabBar.svelte
+++ b/frontend/src/lib/figma/screens/workspace-settings/TabBar.svelte
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <!--
-    Copyright (C) 2023 JWP Consulting GK
+    Copyright (C) 2023-2024 JWP Consulting GK
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as published
@@ -19,6 +19,7 @@
     import { _ } from "svelte-i18n";
 
     import TabElement from "$lib/figma/buttons/TabElement.svelte";
+    import { currentWorkspaceUserCan } from "$lib/stores/dashboard/workspaceUser";
     import type { SettingKind } from "$lib/types/dashboard";
     import type { Workspace } from "$lib/types/workspace";
     import { getSettingsUrl } from "$lib/urls";
@@ -38,10 +39,12 @@
         label={$_("workspace-settings.workspace-users.title")}
         active={activeSetting === "workspace-users"}
     />
-    <TabElement
-        href={getSettingsUrl(workspace.uuid, "billing")}
-        label={$_("workspace-settings.billing.title")}
-        active={activeSetting === "billing"}
-    />
+    {#if $currentWorkspaceUserCan("read", "customer")}
+        <TabElement
+            href={getSettingsUrl(workspace.uuid, "billing")}
+            label={$_("workspace-settings.billing.title")}
+            active={activeSetting === "billing"}
+        />
+    {/if}
     <div class="grow border-b-2 border-border" />
 </div>

--- a/frontend/src/lib/rules/workspace.ts
+++ b/frontend/src/lib/rules/workspace.ts
@@ -61,6 +61,7 @@ type Rules = {
 | Task label              | Member     | Observer   | Member     | Member     |
 | Sub task                | Member     | Observer   | Member     | Member     |
 | Chat message            | Member     | Observer   | Member     | Maintainer |
+| Customer                | Owner      | Owner      | Owner      | Owner      |
  */
 
 const rules: Rules = {

--- a/frontend/src/lib/rules/workspace.ts
+++ b/frontend/src/lib/rules/workspace.ts
@@ -37,7 +37,8 @@ export type Resource =
     | "label"
     | "taskLabel"
     | "subTask"
-    | "chatMessage";
+    | "chatMessage"
+    | "customer";
 
 type CrudMinimumRole = {
     [K in Verb]: WorkspaceUserRole;
@@ -124,6 +125,12 @@ const rules: Rules = {
         read: "OBSERVER",
         update: "MEMBER",
         delete: "MAINTAINER",
+    },
+    customer: {
+        create: "OWNER",
+        read: "OWNER",
+        update: "OWNER",
+        delete: "OWNER",
     },
 };
 


### PR DESCRIPTION
The tab bar item "billing" would be visible, even if a user did not have permission to access it. There would be a 403 error from the backend as well, since there it would fail the permission check if a user isn't owner of a workspace.