### PR TITLE
FE: Consider quotas for permission checks as well

### DIFF
--- a/frontend/src/lib/stores/dashboard/workspaceUser.ts
+++ b/frontend/src/lib/stores/dashboard/workspaceUser.ts
@@ -90,18 +90,28 @@ type CurrentWorkspaceUserCan = Readable<
  * currently active, logged in user's workspace user.
  */
 export const currentWorkspaceUserCan: CurrentWorkspaceUserCan = derived<
-    CurrentWorkspaceUser,
+    [CurrentWorkspaceUser, typeof currentWorkspace],
     (verb: Verb, resource: Resource) => boolean
 >(
-    currentWorkspaceUser,
-    ($currentWorkspaceUser, set) => {
+    [currentWorkspaceUser, currentWorkspace],
+    ([$currentWorkspaceUser, $currentWorkspace], set) => {
         if ($currentWorkspaceUser === undefined) {
             console.warn("workspaceUser was undefined");
             set(() => false);
             return;
         }
+        if ($currentWorkspace === undefined) {
+            console.warn("workspace was undefined");
+            set(() => false);
+            return;
+        }
         const fn = (verb: Verb, resource: Resource) =>
-            can(verb, resource, $currentWorkspaceUser);
+            can(
+                verb,
+                resource,
+                $currentWorkspaceUser,
+                $currentWorkspace.quota,
+            );
         set(fn);
     },
     () => false,


### PR DESCRIPTION
For example, when workspace_users_and_invites.can_create_more is false, the invite workspace user button will be hidden.

It would be better if there are two types of missing permission: 1) Privilege
2) Quota

For the second one it would be wise to show a disabled button instead of a hidden button.