### PR TITLE
Add small settings and dashboard tweaks

### DIFF
--- a/frontend/src/lib/figma/screens/workspace-settings/WorkspaceUserCard.svelte
+++ b/frontend/src/lib/figma/screens/workspace-settings/WorkspaceUserCard.svelte
@@ -138,6 +138,7 @@
                 action={{
                     kind: "button",
                     action: removeUser,
+                    disabled: isCurrentUser,
                 }}
                 style={{
                     kind: "tertiary",

--- a/frontend/src/lib/stores/dashboard/task.ts
+++ b/frontend/src/lib/stores/dashboard/task.ts
@@ -54,7 +54,7 @@ export function searchTasks(
     );
     const tasks = sectionTasks.flat();
     return searchAmong<TaskWithWorkspaceBoardSection>(
-        ["title", "number"],
+        ["workspace_board_section.title", "title", "number"],
         tasks,
         searchText,
     );

--- a/frontend/src/messages/en.ts
+++ b/frontend/src/messages/en.ts
@@ -779,6 +779,13 @@ const messages: MessageDirectory = {
                 "label": "Upload a picture",
                 "remove-picture": "Remove picture",
             },
+            "delete": {
+                title: "Workspace deletion",
+                message:
+                    "If you would like to delete this workspace, please send us an email using the link below. We have not implemented self-serve workspace deletion at this point, and would like to apologize for the inconvenience.",
+                label: "Request workspace deletion (opens email client)",
+                email: "mailto:hello@projectifyapp.com?subject=Workspace+deletion",
+            },
         },
         "workspace-users": {
             "title": "Workspace users",

--- a/frontend/src/routes/(platform)/dashboard/workspace/[workspaceUuid]/settings/+page.svelte
+++ b/frontend/src/routes/(platform)/dashboard/workspace/[workspaceUuid]/settings/+page.svelte
@@ -22,6 +22,7 @@
     import UploadAvatar from "$lib/figma/buttons/UploadAvatar.svelte";
     import Button from "$lib/funabashi/buttons/Button.svelte";
     import InputField from "$lib/funabashi/input-fields/InputField.svelte";
+    import Anchor from "$lib/funabashi/typography/Anchor.svelte";
     import { updateWorkspace } from "$lib/repository/workspace";
     import { currentWorkspaceUserCan } from "$lib/stores/dashboard/workspaceUser";
     import type { EditableViewState } from "$lib/types/ui";
@@ -175,3 +176,18 @@
         {/if}
     </div>
 </form>
+{#if $currentWorkspaceUserCan("delete", "workspace")}
+    <section class="flex flex-col gap-2">
+        <h2 class="font-bold">
+            {$_("workspace-settings.general.delete.title")}
+        </h2>
+
+        <p>
+            {$_("workspace-settings.general.delete.message")}
+        </p>
+        <Anchor
+            label={$_("workspace-settings.general.delete.label")}
+            href={$_("workspace-settings.general.delete.email")}
+        />
+    </section>
+{/if}

--- a/frontend/src/routes/(platform)/dashboard/workspace/[workspaceUuid]/settings/quota/+page.svelte
+++ b/frontend/src/routes/(platform)/dashboard/workspace/[workspaceUuid]/settings/quota/+page.svelte
@@ -20,12 +20,13 @@
     import { _ } from "svelte-i18n";
 
     import Anchor from "$lib/funabashi/typography/Anchor.svelte";
+    import { currentWorkspace } from "$lib/stores/dashboard";
     import type { Quota } from "$lib/types/workspace";
 
     import type { PageData } from "./$types";
 
     export let data: PageData;
-    const { workspace } = data;
+    $: workspace = $currentWorkspace ?? data.workspace;
 
     $: quotaRows = [
         {


### PR DESCRIPTION
- Allow searching tasks by their section title
- Add instructions for how to request workspace deletion, since self-service delete is not supported right now.
- Disable workspace user remove button for own user, otherwise we'd get a 400 because the backend won't let you (also, removing yourself accidentally? yikes)
- Reactively update the ws quota page using ws subscription store