### PR TITLE
FE: Fix issue with label pill height difference

### DIFF
--- a/frontend/src/lib/figma/cards/task-card/Labels.svelte
+++ b/frontend/src/lib/figma/cards/task-card/Labels.svelte
@@ -107,7 +107,7 @@
     </div>
 {:else if canUpdate}
     <button
-        class="flex flex-row items-center self-start rounded-xl border border-dashed border-primary px-4 py-1 font-bold text-primary"
+        class="flex flex-row items-center self-start rounded-full px-4 py-1 font-bold text-primary outline outline-dashed outline-1 outline-primary"
         on:click|preventDefault={openLabelPicker}
     >
         {$_("dashboard.task-card.add-label")}</button


### PR DESCRIPTION
In task card, Label pill in assign mode would have different height because of border. Switch to using outline to have label pill in assign mode have same height as when labels are selected.