### PR TITLE
Fix focus trap in constructive overlay

### DIFF
--- a/frontend/src/lib/figma/overlays/constructive/Layout.svelte
+++ b/frontend/src/lib/figma/overlays/constructive/Layout.svelte
@@ -24,7 +24,6 @@
         <slot name="title" />
     </h1>
     <form class="flex flex-col gap-8" on:submit|preventDefault={onSubmit}>
-        <input type="submit" class="hidden" />
         {#if $$slots.message}
             <slot name="message" />
         {/if}


### PR DESCRIPTION
For reasons, the focus trap within a constructive overlay did not work well. It seems like removing the hidden submit button fixed the issue. (tested only in Firefox ESR in Debian 12...)