### PR TITLE
BE: Update django-anymail to 10.3

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -633,23 +633,24 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-anymail"
-version = "8.6"
-description = "Django email backends and webhooks for Amazon SES, Mailgun, Mailjet, Mandrill, Postal, Postmark, SendGrid, SendinBlue, and SparkPost"
+version = "10.3"
+description = "Django email backends and webhooks for Amazon SES, Brevo (Sendinblue),     MailerSend, Mailgun, Mailjet, Mandrill, Postal, Postmark, Resend,     SendGrid, SparkPost and Unisender Go"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 files = [
-    {file = "django-anymail-8.6.tar.gz", hash = "sha256:783342d49dd07d68778b81dd12a94c86e1d217463a68a85450a0513fabe31345"},
-    {file = "django_anymail-8.6-py3-none-any.whl", hash = "sha256:49d83d7c16316ca86a624097496881d59b7d71b16bf1c5211cffa5b19ef98d0c"},
+    {file = "django_anymail-10.3-py3-none-any.whl", hash = "sha256:1e72f059e96930d3675d35fe4c61f82b138ae4a7fcb0337be39dcb4823f94a4f"},
+    {file = "django_anymail-10.3.tar.gz", hash = "sha256:35d8ec20b06000af3c1638492e32f416fd1a584f0a572cded03f1bc570169ed0"},
 ]
 
 [package.dependencies]
 django = ">=2.0"
 requests = ">=2.4.3"
+urllib3 = ">=1.25.0"
 
 [package.extras]
 amazon-ses = ["boto3"]
-dev = ["flake8", "sphinx", "sphinx-rtd-theme", "tox", "twine", "wheel"]
 postal = ["cryptography"]
+resend = ["svix"]
 
 [[package]]
 name = "django-celery-results"
@@ -2306,4 +2307,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "8658d053cc49c79bd4f9a52d10bed1dd35b93448d0b978541566dfa7bb03fa2a"
+content-hash = "48ae60b9e0138f9f190d6365a63102afb4b5bdd4bd73bf8a9cbcf4f94a4ea569"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -130,7 +130,7 @@ channels-redis = "~4.0.0"
 cryptography = "42.0.4"
 dj-database-url = "~2.1.0"
 django = "~5"
-django-anymail = {extras = ["mailgun"], version = "~8.6"}
+django-anymail = {extras = ["mailgun"], version = "~10.3"}
 django-celery-results = "~2.5.0"
 django-cloudinary-storage = "~0.3.0"
 django-configurations = "^2.4.1"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -236,9 +236,9 @@ daphne==4.0.0 ; python_version >= "3.11" and python_version < "3.12" \
 dj-database-url==2.1.0 ; python_version >= "3.11" and python_version < "3.12" \
     --hash=sha256:04bc34b248d4c21aaa13e4ab419ae6575ef5f10f3df735ce7da97722caa356e0 \
     --hash=sha256:f2042cefe1086e539c9da39fad5ad7f61173bf79665e69bf7e4de55fa88b135f
-django-anymail[mailgun]==8.6 ; python_version >= "3.11" and python_version < "3.12" \
-    --hash=sha256:49d83d7c16316ca86a624097496881d59b7d71b16bf1c5211cffa5b19ef98d0c \
-    --hash=sha256:783342d49dd07d68778b81dd12a94c86e1d217463a68a85450a0513fabe31345
+django-anymail[mailgun]==10.3 ; python_version >= "3.11" and python_version < "3.12" \
+    --hash=sha256:1e72f059e96930d3675d35fe4c61f82b138ae4a7fcb0337be39dcb4823f94a4f \
+    --hash=sha256:35d8ec20b06000af3c1638492e32f416fd1a584f0a572cded03f1bc570169ed0
 django-celery-results==2.5.1 ; python_version >= "3.11" and python_version < "3.12" \
     --hash=sha256:0da4cd5ecc049333e4524a23fcfc3460dfae91aa0a60f1fae4b6b2889c254e01 \
     --hash=sha256:3ecb7147f773f34d0381bac6246337ce4cf88a2ea7b82774ed48e518b67bb8fd


### PR DESCRIPTION
django-anymail used a deprecated Django API (django.utils.timezone.utc)

Updating to the new API was done in v9.0 released 2022-12-18 (ouch)

Update django-anymail to fix sending emails.