### PR TITLE
FE: Add frame-src and frame-ancestors CSP

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -44,6 +44,8 @@ const config = {
         csp: {
             directives: {
                 "script-src": ["self"],
+                "frame-ancestors": ["none"],
+                "frame-src": ["none"],
             },
         },
         typescript: {


### PR DESCRIPTION
Out of an abundance of caution, I add two CSP directives that (mostly) prevent clickjacking.

Note that with prerendered pages frame-ancestors is ignored:

https://kit.svelte.dev/docs/configuration#csp