### PR TITLE
Netlify: Prevent clickjacking with CSP header

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,3 +12,8 @@ NODE_ENV = "production"
 from = "/*"
 to = "/redirect.html"
 status = 200
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "frame-ancestors 'none'"


### PR DESCRIPTION
On top of SvelteKit's static pages only sometimes containing all specified csp <meta> tags, we also want to return a strict CSP header from Netlify, directly.

Regarding having multiple policies on the same page, the stricter one will be adopted by the browser, see:

https://w3c.github.io/webappsec-csp/#multiple-policies