### PR TITLE
Simplify gunicorn conf. / Procfile

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,3 +1,3 @@
 release: ./manage.py migrate --noinput
-web: newrelic-admin run-program gunicorn projectify.asgi -w 1 -b "0.0.0.0:$PORT" -k uvicorn.workers.UvicornWorker --log-config gunicorn-error.log
-worker: newrelic-admin run-program celery -A projectify worker -c 1
+web: newrelic-admin run-program gunicorn
+worker: newrelic-admin run-program celery --app projectify worker --concurrency 1

--- a/backend/bin/test-production-bootup
+++ b/backend/bin/test-production-bootup
@@ -46,12 +46,7 @@ then
     exit 1
 fi
 
-poetry run newrelic-admin run-program \
-    gunicorn projectify.asgi \
-    --workers 1 \
-    --bind "0.0.0.0:$PORT" \
-    --worker-class uvicorn.workers.UvicornWorker \
-    --log-config gunicorn-error.log &
+poetry run newrelic-admin run-program gunicorn &
 PID1="$!"
 poetry run newrelic-admin run-program \
     celery --app projectify \

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Copyright (C) 2023 JWP Consulting GK
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Configuration for Gunicorn to use with Projectify application."""
+import os
+
+wsgi_app = "projectify.asgi"
+
+# Refer to
+# https://docs.gunicorn.org/en/stable/configure.html#configuration-file
+bind = f"0.0.0.0:{os.environ['PORT']}"
+
+# The docs recommend:
+# import multiprocessing
+# workers = multiprocessing.cpu_count() * 2 + 1
+workers = 1
+worker_class = "uvicorn.workers.UvicornWorker"
+
+logconfig = "gunicorn-error.log"


### PR DESCRIPTION
Create a new gunicorn config file as specified in gunicorn docs. Use it in production startup test and Procfile (used in Heroku)