### PR TITLE
Add landing page for ethical ads, polish non-javascript loading experience

### DIFF
--- a/frontend/src/lib/components/help/Layout.svelte
+++ b/frontend/src/lib/components/help/Layout.svelte
@@ -41,7 +41,7 @@
     >
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <Hero slot="hero" {heroContent} />
     <nav slot="side" class="flex grow flex-col gap-4 sm:max-w-xs">
         <h2 class="text-3xl font-bold">{$_("help.help-sections")}</h2>

--- a/frontend/src/lib/components/layouts/HeroLayout.svelte
+++ b/frontend/src/lib/components/layouts/HeroLayout.svelte
@@ -16,7 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <script lang="ts">
-    export let heroBackground = true;
+    export let heroBackground: boolean;
     export let isProseContent = false;
 </script>
 
@@ -27,7 +27,7 @@
 >
     {#if $$slots.hero}
         <div
-            class="flex w-full flex-col items-center bg-background"
+            class="flex w-full flex-col items-center"
             class:bg-background={heroBackground}
         >
             <div class="w-full max-w-4xl px-6 py-6 sm:py-12">

--- a/frontend/src/lib/components/solutions/SolutionsPage.svelte
+++ b/frontend/src/lib/components/solutions/SolutionsPage.svelte
@@ -34,7 +34,7 @@
     >
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <Hero slot="hero" heroContent={pageContent.heroContent} />
 
     <div

--- a/frontend/src/lib/funabashi/buttons/HeaderButton.svelte
+++ b/frontend/src/lib/funabashi/buttons/HeaderButton.svelte
@@ -21,7 +21,7 @@
     export let label: string;
     export let action: ButtonAction;
     const buttonClass =
-        "text-base-content flex flex-row items-center gap-2 rounded-lg p-2 hover:text-primary focus:outline-none focus:ring-1 focus:ring-border-focus focus:ring-offset-2 active:text-primary";
+        "text-base-content flex flex-row items-center gap-2 rounded-lg p-2 hover:text-primary active:text-primary";
 </script>
 
 {#if action.kind === "button"}

--- a/frontend/src/routes/(onboarding)/+layout.ts
+++ b/frontend/src/routes/(onboarding)/+layout.ts
@@ -25,4 +25,4 @@ export { load };
 // TODO check
 export const prerender = false;
 // SSR, this can be prerendered
-export const ssr = false;
+export const ssr = true;

--- a/frontend/src/routes/(platform)/+layout.ts
+++ b/frontend/src/routes/(platform)/+layout.ts
@@ -54,4 +54,6 @@ export async function load({
 // Prerender: This page is completely prerenderable, there is no user data here
 export const prerender = false;
 // SSR, this can be prerendered
+// TODO this can be turned to true
+// Justus 2024-04-26
 export const ssr = false;

--- a/frontend/src/routes/(storefront)/(auth)/+layout.ts
+++ b/frontend/src/routes/(storefront)/(auth)/+layout.ts
@@ -22,7 +22,6 @@ interface Data {
 }
 
 export const prerender = false;
-export const ssr = false;
 
 export function load({ url }: LayoutLoadEvent): Data {
     const redirectTo = url.searchParams.get("next") ?? undefined;

--- a/frontend/src/routes/(storefront)/accessibility/+page.svelte
+++ b/frontend/src/routes/(storefront)/accessibility/+page.svelte
@@ -40,7 +40,7 @@
     <title>{$_("accessibility.title")}</title>
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <Hero slot="hero" {heroContent} />
 
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->

--- a/frontend/src/routes/(storefront)/contact-us/+page.svelte
+++ b/frontend/src/routes/(storefront)/contact-us/+page.svelte
@@ -32,7 +32,7 @@
     <title>{$_("contact-us.title")}</title>
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <Hero {heroContent} slot="hero" />
     <div
         slot="content"

--- a/frontend/src/routes/(storefront)/credits/+page.svelte
+++ b/frontend/src/routes/(storefront)/credits/+page.svelte
@@ -28,7 +28,7 @@
     <title>{$_("credits.title")}</title>
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <div slot="hero">
         <h1 class="text-3xl font-bold">{$_("credits.hero")}</h1>
     </div>

--- a/frontend/src/routes/(storefront)/ethicalads/+page.svelte
+++ b/frontend/src/routes/(storefront)/ethicalads/+page.svelte
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!--
+    Copyright (C) 2024 JWP Consulting GK
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<script lang="ts">
+    import Storefront from "../+page.svelte";
+</script>
+
+<Storefront />

--- a/frontend/src/routes/(storefront)/free-software/+page.svelte
+++ b/frontend/src/routes/(storefront)/free-software/+page.svelte
@@ -25,7 +25,7 @@
     <title>{$_("free-software.title")}</title>
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <div slot="hero">
         <h1 class="text-3xl font-bold">{$_("free-software.hero")}</h1>
     </div>

--- a/frontend/src/routes/(storefront)/help/+page.svelte
+++ b/frontend/src/routes/(storefront)/help/+page.svelte
@@ -42,7 +42,7 @@
     <title>{$_("help.title")}</title>
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <Hero slot="hero" {heroContent} />
     <div slot="content" class="flex w-full flex-col gap-4">
         <div

--- a/frontend/src/routes/(storefront)/privacy/+page.svelte
+++ b/frontend/src/routes/(storefront)/privacy/+page.svelte
@@ -31,7 +31,7 @@
     <title>{$_("privacy-policy.title")}</title>
 </svelte:head>
 
-<HeroLayout isProseContent={true}>
+<HeroLayout isProseContent heroBackground>
     <nav slot="side" class="flex max-w-xs grow flex-col gap-2">
         <p id="top" class="font-bold">{$_("privacy-policy.nav.title")}</p>
         <ol class="list-inside list-disc">

--- a/frontend/src/routes/(storefront)/security/disclose/+page.svelte
+++ b/frontend/src/routes/(storefront)/security/disclose/+page.svelte
@@ -28,7 +28,7 @@
     <title>{$_("security.disclose.title")}</title>
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     <main class="prose" slot="content">{@html markdown.content}</main>
 </HeroLayout>

--- a/frontend/src/routes/(storefront)/security/general/+page.svelte
+++ b/frontend/src/routes/(storefront)/security/general/+page.svelte
@@ -28,7 +28,7 @@
     <title>{$_("security.general.title")}</title>
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     <main class="prose" slot="content">{@html markdown.content}</main>
 </HeroLayout>

--- a/frontend/src/routes/(storefront)/solutions/+page.svelte
+++ b/frontend/src/routes/(storefront)/solutions/+page.svelte
@@ -128,7 +128,7 @@
     <title>{$_("solutions.index.title")}</title>
 </svelte:head>
 
-<HeroLayout>
+<HeroLayout heroBackground>
     <Hero slot="hero" {heroContent} />
     <div
         slot="content"

--- a/frontend/src/routes/(storefront)/tos/+page.svelte
+++ b/frontend/src/routes/(storefront)/tos/+page.svelte
@@ -29,7 +29,7 @@
     <title>{$_("terms-of-service.title")}</title>
 </svelte:head>
 
-<HeroLayout isProseContent={true}>
+<HeroLayout isProseContent heroBackground>
     <nav slot="side" class="flex max-w-xs grow flex-col gap-2">
         <p id="top" class="font-bold">{$_("terms-of-service.nav.title")}</p>
         <ol class="list-inside list-disc">


### PR DESCRIPTION
- Enable SSR for more pages
- Fix weird CSS style flicker in landing hero
- Add landing page for ethical ads (which in turn just shows the original landing page at /)