### PR TITLE
Perform password validation during password change as well

### DIFF
--- a/backend/projectify/user/services/user.py
+++ b/backend/projectify/user/services/user.py
@@ -18,7 +18,9 @@
 import logging
 from typing import Optional
 
+from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import PermissionDenied
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 
@@ -69,6 +71,10 @@ def user_change_password(
         raise serializers.ValidationError(
             {"current_password": _("Incorrect password. Check again.")}
         )
+    try:
+        validate_password(password=new_password, user=user)
+    except DjangoValidationError as e:
+        raise serializers.ValidationError({"policies": e.messages})
     user.set_password(new_password)
     user.save()
 

--- a/backend/schema/schema.yml
+++ b/backend/schema/schema.yml
@@ -94,11 +94,29 @@ paths:
       description: Handle POST.
       tags:
       - user
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangePassword'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ChangePassword'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ChangePassword'
+        required: true
       security:
       - cookieAuth: []
       responses:
-        '200':
+        '204':
           description: No response body
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangePasswordError'
+          description: ''
   /user/user/confirm-email:
     post:
       operationId: user_user_confirm_email_create
@@ -756,6 +774,29 @@ paths:
           description: No response body
 components:
   schemas:
+    ChangePassword:
+      type: object
+      description: Accept old and new password.
+      properties:
+        current_password:
+          type: string
+        new_password:
+          type: string
+      required:
+      - current_password
+      - new_password
+    ChangePasswordError:
+      type: object
+      description: These fields may be populated in a 400 response.
+      properties:
+        current_password:
+          type: string
+        new_password:
+          type: string
+        policies:
+          type: array
+          items:
+            type: string
     PasswordPolicies:
       type: object
       description: Serialize password policies.

--- a/frontend/src/lib/repository/user.ts
+++ b/frontend/src/lib/repository/user.ts
@@ -19,7 +19,6 @@ import vars from "$lib/env";
 import {
     failOrOk,
     getWithCredentialsJson,
-    openApiClient,
     postWithCredentialsJson,
     putWithCredentialsJson,
 } from "$lib/repository/util";
@@ -69,19 +68,6 @@ export async function updateProfilePicture(
         imageFile,
         vars.API_ENDPOINT + "/user/user/profile-picture/upload",
     );
-}
-
-export async function changePassword(
-    current_password: string,
-    new_password: string,
-    // TODO: Think about how to pass this back in, or make the current
-    // fetch a global state perhaps
-    // repositoryContext: RepositoryContext,
-) {
-    return await openApiClient.POST("/user/user/change-password", {
-        body: { current_password, new_password },
-        // credentials: "include",
-    });
 }
 
 export async function requestEmailAddressUpdate(

--- a/frontend/src/lib/repository/user.ts
+++ b/frontend/src/lib/repository/user.ts
@@ -19,6 +19,7 @@ import vars from "$lib/env";
 import {
     failOrOk,
     getWithCredentialsJson,
+    openApiClient,
     postWithCredentialsJson,
     putWithCredentialsJson,
 } from "$lib/repository/util";
@@ -73,15 +74,14 @@ export async function updateProfilePicture(
 export async function changePassword(
     current_password: string,
     new_password: string,
-    repositoryContext: RepositoryContext,
-): Promise<
-    ApiResponse<void, { current_password?: string; new_password?: string }>
-> {
-    return await postWithCredentialsJson(
-        "/user/user/change-password",
-        { current_password, new_password },
-        repositoryContext,
-    );
+    // TODO: Think about how to pass this back in, or make the current
+    // fetch a global state perhaps
+    // repositoryContext: RepositoryContext,
+) {
+    return await openApiClient.POST("/user/user/change-password", {
+        body: { current_password, new_password },
+        // credentials: "include",
+    });
 }
 
 export async function requestEmailAddressUpdate(

--- a/frontend/src/lib/types/schema.d.ts
+++ b/frontend/src/lib/types/schema.d.ts
@@ -185,6 +185,17 @@ export type webhooks = Record<string, never>;
 
 export interface components {
     schemas: {
+        /** @description Accept old and new password. */
+        ChangePassword: {
+            current_password: string;
+            new_password: string;
+        };
+        /** @description These fields may be populated in a 400 response. */
+        ChangePasswordError: {
+            current_password?: string;
+            new_password?: string;
+            policies?: string[];
+        };
         /** @description Serialize password policies. */
         PasswordPolicies: {
             policies: string[];
@@ -285,10 +296,22 @@ export interface operations {
     };
     /** @description Handle POST. */
     user_user_change_password_create: {
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ChangePassword"];
+                "application/x-www-form-urlencoded": components["schemas"]["ChangePassword"];
+                "multipart/form-data": components["schemas"]["ChangePassword"];
+            };
+        };
         responses: {
             /** @description No response body */
-            200: {
+            204: {
                 content: never;
+            };
+            400: {
+                content: {
+                    "application/json": components["schemas"]["ChangePasswordError"];
+                };
             };
         };
     };

--- a/frontend/src/routes/(platform)/user/profile/change-password/+page.svelte
+++ b/frontend/src/routes/(platform)/user/profile/change-password/+page.svelte
@@ -58,10 +58,8 @@
             return;
         }
         state = { kind: "submitting" };
-        const result = await changePassword(currentPassword, newPassword1, {
-            fetch,
-        });
-        if (result.ok) {
+        const result = await changePassword(currentPassword, newPassword1);
+        if (result.error === undefined) {
             await goto(changedPasswordUrl);
             return;
         }
@@ -96,7 +94,7 @@
                 kind: "error",
                 message: $_(
                     "user-account-settings.change-password.validation.general-error",
-                    { values: { detail: JSON.stringify(result.error) } },
+                    { values: { details: JSON.stringify(result.error) } },
                 ),
             };
         } else {

--- a/frontend/src/routes/(platform)/user/profile/change-password/+page.svelte
+++ b/frontend/src/routes/(platform)/user/profile/change-password/+page.svelte
@@ -26,6 +26,7 @@
     import { getProfileUrl } from "$lib/urls";
     import { changedPasswordUrl } from "$lib/urls/user";
     import { openApiClient } from "$lib/repository/util";
+    import { onMount } from "svelte";
 
     let state: FormViewState = { kind: "start" };
 
@@ -35,6 +36,15 @@
     let newPassword1: string | undefined = undefined;
     let newPasswordValidation: InputFieldValidation | undefined = undefined;
     let newPassword2: string | undefined = undefined;
+
+    let passwordPolicies: string[] | undefined = undefined;
+    onMount(async () => {
+        const response = await openApiClient.GET("/user/user/password-policy");
+        if (response.data === undefined) {
+            throw new Error("Could not get password policies");
+        }
+        passwordPolicies = response.data.policies;
+    });
 
     $: canSubmit = state.kind !== "submitting";
 
@@ -161,6 +171,16 @@
             required
             validation={newPasswordValidation}
         />
+        {#if passwordPolicies}
+            <header class="font-bold">
+                {$_("auth.sign-up.password.policies")}
+            </header>
+            <ul class="flex list-inside list-disc flex-col gap-0.5">
+                {#each passwordPolicies as policy}
+                    <li>{policy}</li>
+                {/each}
+            </ul>
+        {/if}
         {#if state.kind === "error"}
             <p>
                 {state.message}


### PR DESCRIPTION
Similar to sign up page,
- show password rules at the bottom of the form
- validate password in backend, and reject with "policies" error
- improve openapi schema to assist frontend type checking
- use openapi-fetch library for request
- add middleware to openapi-fetch in order to include csrftoken
- show new validation error in frontend if password rejected