### PR TITLE
Statically build frontend and revproxy

### DIFF
--- a/revproxy/.envrc
+++ b/revproxy/.envrc
@@ -1,0 +1,1 @@
+use_flake

--- a/revproxy/flake.lock
+++ b/revproxy/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717179513,
+        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/revproxy/flake.nix
+++ b/revproxy/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "Reverse proxy configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/24.05";
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        caddyfile = pkgs.runCommand "Caddyfile" {} ''
+          mkdir $out
+          echo "
+            :5000 {
+              handle /admin/* {
+                reverse_proxy :5002
+              }
+              handle /backend/static/* {
+                reverse_proxy :5002
+              }
+              handle /ws/* {
+                reverse_proxy :5002
+              }
+              handle_path /api/* {
+                reverse_proxy :5002
+              }
+              handle /* {
+                reverse_proxy :5001
+              }
+            }
+          " | ${pkgs.caddy}/bin/caddy fmt - > $out/Caddyfile
+        '';
+        projectify-revproxy = pkgs.writeShellApplication {
+          name = "projectify-revproxy";
+          runtimeInputs = [ pkgs.caddy ];
+          text = ''
+            exec caddy --config "${caddyfile}/Caddyfile" run
+          '';
+        };
+      in
+      {
+        packages = {
+          default = projectify-revproxy;
+          inherit projectify-revproxy;
+        };
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            projectify-revproxy
+          ];
+        };
+      });
+}

--- a/supervisor/flake.lock
+++ b/supervisor/flake.lock
@@ -72,6 +72,24 @@
         "type": "github"
       }
     },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_6"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
@@ -146,7 +164,7 @@
       },
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-d5TX5U8X6dmnvDmUp1oZ+UZvr73hci/GYg7eu81N3vk=",
+        "narHash": "sha256-TPruaWkhRZmw4vBwTB3lFZ7jMy+V3IEzDCTWlnBycfY=",
         "path": "../backend",
         "type": "path"
       },
@@ -164,7 +182,7 @@
       },
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-JFPgV5jVIQPhlMUsrucKD22iSQbfHWbXjWfXI5ZGzMk=",
+        "narHash": "sha256-ycok3LVTHFvuQzbhmtMfW9SHRvwGM7oL66E32AGthvA=",
         "path": "../frontend",
         "type": "path"
       },
@@ -173,12 +191,31 @@
         "type": "path"
       }
     },
+    "projectify-revproxy": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-CfotXHcdZxPDal9S5PjkqMkjDDvhydgrK31bLio38b4=",
+        "path": "../revproxy",
+        "type": "path"
+      },
+      "original": {
+        "path": "../revproxy",
+        "type": "path"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "projectify-backend": "projectify-backend",
-        "projectify-frontend": "projectify-frontend"
+        "projectify-frontend": "projectify-frontend",
+        "projectify-revproxy": "projectify-revproxy"
       }
     },
     "systems": {
@@ -241,6 +278,21 @@
       }
     },
     "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/supervisor/flake.nix
+++ b/supervisor/flake.nix
@@ -6,14 +6,17 @@
 
     projectify-frontend.url = "path:../frontend";
     projectify-backend.url = "path:../backend";
+    projectify-revproxy.url = "path:../revproxy";
 
     projectify-frontend.inputs.nixpkgs.follows = "nixpkgs";
     projectify-backend.inputs.nixpkgs.follows = "nixpkgs";
+    projectify-revproxy.inputs.nixpkgs.follows = "nixpkgs";
+
 
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, projectify-frontend, projectify-backend }:
+  outputs = { self, nixpkgs, flake-utils, projectify-revproxy, projectify-frontend, projectify-backend }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -24,7 +27,7 @@
             adapter = "node";
         };
         backend = projectify-backend.packages.${system}.projectify-backend;
-        static = projectify-backend.packages.${system}.projectify-backend-static;
+        revproxy = projectify-revproxy.packages.${system}.projectify-revproxy;
         nodejs = pkgs.nodejs_20;
       in
       {
@@ -35,15 +38,13 @@
           buildInputs = [
             backend
             frontend
+            revproxy
             pkgs.python311Packages.supervisor
             pkgs.unixtools.watch
             pkgs.coreutils
-            pkgs.caddy
-            nodejs
           ];
           shellHook = ''
-            export STATIC_ROOT=${static}
-            export PROJECTIFY_FRONTEND_PATH=${frontend}
+            export STATIC_ROOT=${backend.static}
             export DJANGO_SETTINGS_MODULE=projectify.settings.development_nix
             export DJANGO_CONFIGURATION=DevelopmentNix
           '';

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -4,12 +4,12 @@ loglevel = debug
 
 [supervisorctl]
 
-[program:projectify-sveltekit]
-command = node %(ENV_PROJECTIFY_FRONTEND_PATH)s
+[program:projectify-frontend]
+command = projectify-frontend
 environment = SVELTE_KIT_PORT=5001
 
-[program:caddy]
-command = caddy run
+[program:projectify-revproxy]
+command = projectify-revproxy
 
 [program:projectify-backend]
 command = projectify-gunicorn --config ../backend/gunicorn.conf.py --log-config ../backend/gunicorn-error.log --access-logfile -


### PR DESCRIPTION
This allows us to launch frontend, using adapter-node, and projectify-revproxy (which in turns wraps Caddy) with one command each.