### PR TITLE
BE: Default to no CSRF cookie domain

### DIFF
--- a/backend/projectify/settings/production.py
+++ b/backend/projectify/settings/production.py
@@ -140,7 +140,7 @@ class Production(Base):
     # and at this point I am afraid to ask.
     MIDDLEWARE = list(populate_production_middleware(Base.MIDDLEWARE))
 
-    CSRF_COOKIE_DOMAIN = os.getenv("CSRF_COOKIE_DOMAIN", ".projectifyapp.com")
+    CSRF_COOKIE_DOMAIN = os.getenv("CSRF_COOKIE_DOMAIN", None)
 
     # Stripe
     STRIPE_PUBLISHABLE_KEY = os.environ["STRIPE_PUBLISHABLE_KEY"]

--- a/docs/backend/configuration.md
+++ b/docs/backend/configuration.md
@@ -21,10 +21,9 @@ Production`
 - `ALLOWED_HOSTS`: Which host names to permit in HTTP Host header. Comma
 separated values.
 - `FRONTEND_URL`: URL for where Projectify frontend is served.
-- `SECURITY_ORIGINS` (**optional**): Allowed URLs for CORS/CSRF. Defaults to
+- `SECURITY_ORIGINS` (**optional**): Allowed URLs for [CORS](https://pypi.org/project/django-cors-headers/)/[CSRF](https://docs.djangoproject.com/en/5.0/ref/settings/#csrf-trusted-origins). Defaults to
 `ALLOWED_HOSTS`.
-- `CSRF_COOKIE_DOMAIN` (**optional**): Domain for CSRF cookie. Defaults to
-`.projectifyapp.com`.
+- `CSRF_COOKIE_DOMAIN` (**optional**): Domain for CSRF cookie. Defaults to None. See [Django documentation](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-CSRF_COOKIE_DOMAIN);
 
 ## Database
 - `DATABASE_URL`:


### PR DESCRIPTION
Important: If an API is served from a subdomain like "api.example.com", and frontend is accessible from "example.com", then CSRF_COOKIE_DOMAIN needs to be set to ".example.om" (note the extra `.` in the beginning)

Update the configuration docs as well