### PR TITLE
Fall back to less strict CSP header when serving static frontend

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -4,13 +4,13 @@
 # Helpful links for Caddy security headers
 # https://github.com/jpcaparas/caddy-csp/blob/f241472610a5a4e4f8d74e0976120bbb2cca84cc/Caddyfile
 # https://paulbradley.dev/caddyfile-web-security-headers/
-(csp_headers) {
-	# We have to make sure we don't override any CSP headers, should SvelteKit
-	# with adapter-node decide to return a header itself
+(frontend_headers) {
+	# We need to relax the CSP a bit, since Svelte has some inline js.
+	# Compared to backend_headers, we removed default-src and script-src
+	# Furthermore, we have to make sure we don't override any CSP headers
+	# Should SvelteKit with adapter-node decide to return a header itself
 	header ?Content-Security-Policy "
-		default-src 'self';
 		style-src 'self';
-		script-src 'self';
 		font-src 'self';
 		img-src 'self' res.cloudinary.com;
 		form-action 'self';
@@ -19,7 +19,24 @@
 		object-src 'self';
 		base-uri 'self';
 	"
-	# TODO add default-src 'none', at least as a report directive
+}
+(backend_headers) {
+	# The backend is locked down more
+	header {
+		Content-Security-Policy "
+			default-src 'self';
+			style-src 'self';
+			script-src 'self';
+			font-src 'self';
+			img-src 'self' res.cloudinary.com;
+			form-action 'self';
+			connect-src 'self';
+			frame-ancestors 'none';
+			object-src 'self';
+			base-uri 'self';
+		"
+		# TODO add default-src 'none', at least as a report directive
+	}
 }
 
 # The additional host requires setting the port within the variable.
@@ -35,20 +52,24 @@
 		# TODO add this:
 		# X-Content-Type-Options nosniff
 	}
-	import csp_headers
 	handle /admin/* {
+		import backend_headers
 		reverse_proxy {$BACKEND_HOST}:{$BACKEND_PORT}
 	}
 	handle /static/django/* {
+		import backend_headers
 		reverse_proxy {$BACKEND_HOST}:{$BACKEND_PORT}
 	}
 	handle /ws/* {
+		import backend_headers
 		reverse_proxy {$BACKEND_HOST}:{$BACKEND_PORT}
 	}
 	handle_path /api/* {
+		import backend_headers
 		reverse_proxy {$BACKEND_HOST}:{$BACKEND_PORT}
 	}
 	handle /* {
+		import frontend_headers
 		reverse_proxy {$FRONTEND_HOST}:{$FRONTEND_PORT}
 	}
 }

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -44,9 +44,17 @@ const config = {
         adapter,
         csp: {
             directives: {
+                // Mirrors root directory Caddyfile csp_headers
+                "default-src": ["self"],
+                "style-src": ["self"],
                 "script-src": ["self"],
+                "font-src": ["self"],
+                "img-src": ["self", "res.cloudinary.com"],
+                "form-action": ["self"],
+                "connect-src": ["self"],
                 "frame-ancestors": ["none"],
-                "frame-src": ["none"],
+                "object-src": ["self"],
+                "base-uri": ["self"],
             },
         },
         typescript: {

--- a/stories/package-lock.json
+++ b/stories/package-lock.json
@@ -11,7 +11,6 @@
                 "@anephenix/sarus": "~0.5",
                 "@steeze-ui/heroicons": "~1.1.1",
                 "@steeze-ui/svelte-icon": "~1.5.0",
-                "@sveltejs/adapter-static": "~3.0.1",
                 "@sveltejs/kit": "~2.5.10",
                 "@tailwindcss/typography": "~0.5.13",
                 "autoprefixer": "~10.4.19",
@@ -5115,14 +5114,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/storybook"
-            }
-        },
-        "node_modules/@sveltejs/adapter-static": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.1.tgz",
-            "integrity": "sha512-6lMvf7xYEJ+oGeR5L8DFJJrowkefTK6ZgA4JiMqoClMkKq0s6yvsd3FZfCFvX1fQ0tpCD7fkuRVHsnUVgsHyNg==",
-            "peerDependencies": {
-                "@sveltejs/kit": "^2.0.0"
             }
         },
         "node_modules/@sveltejs/kit": {

--- a/stories/package.json
+++ b/stories/package.json
@@ -59,7 +59,6 @@
         "@anephenix/sarus": "~0.5",
         "@steeze-ui/heroicons": "~1.1.1",
         "@steeze-ui/svelte-icon": "~1.5.0",
-        "@sveltejs/adapter-static": "~3.0.1",
         "@sveltejs/kit": "~2.5.10",
         "@tailwindcss/typography": "~0.5.13",
         "autoprefixer": "~10.4.19",

--- a/stories/svelte.config.js
+++ b/stories/svelte.config.js
@@ -15,9 +15,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
-import frontendSvelte from "../frontend/svelte";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -31,7 +29,6 @@ const config = {
             "$routes": "src/routes",
             "$lib-stories": "src/lib-stories",
         },
-        csp: frontendSvelte.kit.csp,
         typescript: {
             config(config) {
                 return {

--- a/stories/svelte.config.js
+++ b/stories/svelte.config.js
@@ -17,6 +17,7 @@
  */
 import adapter from "@sveltejs/adapter-static";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+import frontendSvelte from "../frontend/svelte";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -42,21 +43,7 @@ const config = {
             precompress: false,
             strict: true,
         }),
-        csp: {
-            directives: {
-                // Mirrors root directory Caddyfile csp_headers
-                "default-src": ["self"],
-                "style-src": ["self"],
-                "script-src": ["self"],
-                "font-src": ["self"],
-                "img-src": ["self", "res.cloudinary.com"],
-                "form-action": ["self"],
-                "connect-src": ["self"],
-                "frame-ancestors": ["none"],
-                "object-src": ["self"],
-                "base-uri": ["self"],
-            },
-        },
+        csp: frontendSvelte.kit.csp,
         typescript: {
             config(config) {
                 return {

--- a/stories/svelte.config.js
+++ b/stories/svelte.config.js
@@ -31,18 +31,6 @@ const config = {
             "$routes": "src/routes",
             "$lib-stories": "src/lib-stories",
         },
-        adapter: adapter({
-            pages: "build",
-            assets: "build",
-            /* XXX we get this error:
-             * > Using @sveltejs/adapter-static
-             * Overwriting build/redirect.html with fallback page. Consider
-             * using a different name for the fallback.
-             */
-            fallback: "redirect.html",
-            precompress: false,
-            strict: true,
-        }),
         csp: frontendSvelte.kit.csp,
         typescript: {
             config(config) {


### PR DESCRIPTION
When serving the static frontend through adapter-node and Caddy, we don't receive a CSP from "upstream", i.e., the node server that Caddy forwards requests from as a reverse proxy. This means that we fall back to an extremely strict CSP in the HTTP header.

The problem is that the script nonces are part of the HTML returned itself. CSPs can't go from strict to less-strict, so having a strict CSP header means that the less-strict CSP meta tags will be ignored. This leads to the frontend not running any JavaScript on prerendered pages.

The solution is to revert part of the recent Caddy CSP changes, but only for when no CSP header is returned from adapter-node. In that case we fall back to a less strict CSP. This is not ideal. Adapter-node could return to us a full set of CSP headers as part of the HTTP response.