### PR TITLE
Mitigate stale domain CSRF issues

### DIFF
--- a/backend/mypy/stubs/rest_framework/test.pyi
+++ b/backend/mypy/stubs/rest_framework/test.pyi
@@ -8,6 +8,7 @@ from django.contrib.auth.models import (
 )
 from django.test.client import Client as DjangoClient
 
+import requests
 from rest_framework.request import Request
 from rest_framework.response import (
     Response,
@@ -82,3 +83,5 @@ class APIClient(APIRequestFactory, DjangoClient):
         follow: bool = False,
         **extra: object,
     ) -> Response: ...
+
+class RequestsClient(requests.Session): ...

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -2331,6 +2331,20 @@ cryptography = ">=35.0.0"
 types-pyOpenSSL = "*"
 
 [[package]]
+name = "types-requests"
+version = "2.32.0.20240712"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-requests-2.32.0.20240712.tar.gz", hash = "sha256:90c079ff05e549f6bf50e02e910210b98b8ff1ebdd18e19c873cd237737c1358"},
+    {file = "types_requests-2.32.0.20240712-py3-none-any.whl", hash = "sha256:f754283e152c752e46e70942fa2a146b5bc70393522257bb85bd1ef7e019dcc3"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
+
+[[package]]
 name = "types-tqdm"
 version = "4.66.0.2"
 description = "Typing stubs for tqdm"
@@ -2567,4 +2581,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11.6"
-content-hash = "9f2f28643cd9c4b8c6f3a6ca5fa96fd6aea86cc4917a12623a82f8f85469cca9"
+content-hash = "b687ef137c7dbe7232529817e622ebf4f178ec0852ab0fa672398ee707dd5ad4"

--- a/backend/projectify/settings/base.py
+++ b/backend/projectify/settings/base.py
@@ -78,12 +78,12 @@ class Base(Configuration):
 
     FRONTEND_URL: str
 
-    SESSION_COOKIE_SAMESITE = "None"
+    SESSION_COOKIE_SAMESITE = "Strict"
     SESSION_COOKIE_SECURE = True
 
     # CSRF
     CSRF_USE_SESSIONS = False
-    CSRF_COOKIE_SAMESITE = "None"
+    CSRF_COOKIE_SAMESITE = "Strict"
     CSRF_COOKIE_SECURE = True
     CSRF_TRUSTED_ORIGINS: Optional[Sequence[str]]
 

--- a/backend/projectify/user/views/auth.py
+++ b/backend/projectify/user/views/auth.py
@@ -88,7 +88,6 @@ class SignUp(views.APIView):
             rate="4/h",
             increment=False,
         )
-        print(limit)
         if limit and limit["should_limit"]:
             raise Throttled()
 
@@ -104,7 +103,7 @@ class SignUp(views.APIView):
         )
 
         # Increment limit only on success
-        usage = get_usage(
+        get_usage(
             request,
             group="projectify.user.views.auth.SignUp.post",
             key="ip",
@@ -112,7 +111,6 @@ class SignUp(views.APIView):
             increment=True,
         )
 
-        print(usage)
         return Response(status=HTTP_204_NO_CONTENT)
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -202,6 +202,7 @@ pytest-xdist = {extras = ["psutil"], version = "~3.3.1"}
 types-redis = "~4.6.0.5"
 types-tqdm = "~4.66.0.2"
 vulture = "^2.9.1"
+types-requests = "^2.32.0.20240712"
 
 [build-system]
 requires = ["poetry-core"]

--- a/frontend/src/lib/utils/cookie.ts
+++ b/frontend/src/lib/utils/cookie.ts
@@ -24,7 +24,7 @@ export function getCookie(name: string): string | undefined {
     }
     const cookies = document.cookie.split(";");
     const cookiesTrimmed = cookies.map((cookie) => cookie.trim());
-    const maybeCookie = cookiesTrimmed.find((cookie) =>
+    const maybeCookie = cookiesTrimmed.findLast((cookie) =>
         cookie.startsWith(`${name}=`),
     );
     if (!maybeCookie) {


### PR DESCRIPTION
Some users might not be able to pass CSRF checks because of a previously set CSRF tokens. This branch introduces the following changes:

- Add a CSRF check failure test case.
- Prefer the last cookie found in getCookie(). I assume this chooses the most recently inserted cookie, although that's not guaranteed to be true.
- Make cookie samesite policies strict, since we serve everything through the same domain now.
- Remove some stray print()s