### PR TITLE
BE: Fix broken mailgun URL

### DIFF
--- a/backend/projectify/settings/production.py
+++ b/backend/projectify/settings/production.py
@@ -81,6 +81,7 @@ class Production(Base):
     ANYMAIL = {
         "MAILGUN_API_KEY": os.environ["MAILGUN_API_KEY"],
         "MAILGUN_SENDER_DOMAIN": os.environ["MAILGUN_DOMAIN"],
+        "MAILGUN_API_URL": "https://api.eu.mailgun.net/v3",
     }
     EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 


### PR DESCRIPTION
We switched to the EU mailgun server, but forgot to update the API URL in the settings.

Thankfully, django-anymail's docs had a solution ready

https://anymail.dev/en/stable/esps/mailgun/#settings