### PR TITLE
BE: Install django-markdownify

### DIFF
--- a/backend/flake.nix
+++ b/backend/flake.nix
@@ -61,6 +61,9 @@
             }
           );
           cryptography = pkgs.python312Packages.cryptography;
+          # This refuses to build because Poetry can't deal with the syntax
+          # of project.license in markdown's pyproject.toml file
+          markdown = pkgs.python312Packages.markdown;
         } // (builtins.mapAttrs
           (package: build-requirements: (
             (builtins.getAttr package super).overridePythonAttrs (old: {

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -121,6 +121,24 @@ files = [
 ]
 
 [[package]]
+name = "bleach"
+version = "6.2.0"
+description = "An easy safelist-based HTML-sanitizing tool."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "bleach-6.2.0-py3-none-any.whl", hash = "sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e"},
+    {file = "bleach-6.2.0.tar.gz", hash = "sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f"},
+]
+
+[package.dependencies]
+tinycss2 = {version = ">=1.1.0,<1.5", optional = true, markers = "extra == \"css\""}
+webencodings = "*"
+
+[package.extras]
+css = ["tinycss2 (>=1.1.0,<1.5)"]
+
+[[package]]
 name = "celery"
 version = "5.4.0"
 description = "Distributed Task Queue."
@@ -841,6 +859,22 @@ files = [
 Django = ">=3.2"
 
 [[package]]
+name = "django-markdownify"
+version = "0.9.5"
+description = "Markdown template filter for Django."
+optional = false
+python-versions = "*"
+files = [
+    {file = "django_markdownify-0.9.5-py3-none-any.whl", hash = "sha256:2c4ae44e386c209453caf5e9ea1b74f64535985d338ad2d5ad5e7089cc94be86"},
+    {file = "django_markdownify-0.9.5.tar.gz", hash = "sha256:34c34eba4a797282a5c5bd97b13cec84d6a4c0673ad47ce1c1d000d74dd8d4ab"},
+]
+
+[package.dependencies]
+bleach = {version = ">=5.0.0", extras = ["css"]}
+Django = "*"
+markdown = "*"
+
+[[package]]
 name = "django-pgtrigger"
 version = "4.11.0"
 description = "Postgres trigger support integrated with Django models."
@@ -1302,6 +1336,21 @@ sqlalchemy = ["sqlalchemy (>=1.4.48,<2.1)"]
 sqs = ["boto3 (>=1.26.143)", "pycurl (>=7.43.0.5)", "urllib3 (>=1.26.16)"]
 yaml = ["PyYAML (>=3.10)"]
 zookeeper = ["kazoo (>=2.8.0)"]
+
+[[package]]
+name = "markdown"
+version = "3.8"
+description = "Python implementation of John Gruber's Markdown."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "markdown-3.8-py3-none-any.whl", hash = "sha256:794a929b79c5af141ef5ab0f2f642d0f7b1872981250230e72682346f7cc90dc"},
+    {file = "markdown-3.8.tar.gz", hash = "sha256:7df81e63f0df5c4b24b7d156eb81e4690595239b7d70937d0409f1b0de319c6f"},
+]
+
+[package.extras]
+docs = ["mdx_gh_links (>=0.2)", "mkdocs (>=1.6)", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-nature (>=0.6)", "mkdocs-section-index", "mkdocstrings[python]"]
+testing = ["coverage", "pyyaml"]
 
 [[package]]
 name = "matplotlib-inline"
@@ -2520,6 +2569,24 @@ requests = {version = ">=2.20", markers = "python_version >= \"3.0\""}
 typing-extensions = {version = ">=4.5.0", markers = "python_version >= \"3.7\""}
 
 [[package]]
+name = "tinycss2"
+version = "1.4.0"
+description = "A tiny CSS parser"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289"},
+    {file = "tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7"},
+]
+
+[package.dependencies]
+webencodings = ">=0.4"
+
+[package.extras]
+doc = ["sphinx", "sphinx_rtd_theme"]
+test = ["pytest", "ruff"]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -2780,6 +2847,17 @@ files = [
 ]
 
 [[package]]
+name = "webencodings"
+version = "0.5.1"
+description = "Character encoding aliases for legacy web content"
+optional = false
+python-versions = "*"
+files = [
+    {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
+    {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
+
+[[package]]
 name = "websockets"
 version = "10.3"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
@@ -2900,4 +2978,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "94f3d0b5d296b9be35f03fbd85c8379c5f701eb226c96028ba4b130c043f0d7d"
+content-hash = "789c55f2ffc895e45a859e052b95e720dc113062c2051c375687c12d7dc46069"

--- a/backend/projectify/settings/base.py
+++ b/backend/projectify/settings/base.py
@@ -90,6 +90,7 @@ class Base(Configuration):
         "rest_framework",
         "rules.apps.AutodiscoverRulesConfig",
         "tailwind",
+        "markdownify.apps.MarkdownifyConfig",
     )
 
     INSTALLED_APPS_FIRST_PARTY = (
@@ -317,6 +318,27 @@ class Base(Configuration):
 
     # Feature flags
     ENABLE_DJANGO_DASHBOARD = False
+
+    # Markdownify
+    MARKDOWNIFY = {
+        "default": {
+            "WHITELIST_TAGS": [
+                "a",
+                "abbr",
+                "acronym",
+                "b",
+                "blockquote",
+                "em",
+                "i",
+                "li",
+                "ol",
+                "p",
+                "strong",
+                "ul",
+                "h1",
+            ]
+        }
+    }
 
     @classmethod
     def post_setup(cls) -> None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,6 +40,7 @@ whitenoise = "~6.2.0"
 django-ratelimit = "^4.1.0"
 django-tailwind = {extras = ["reload"], version = "^3.8.0"}
 django-components = "^0.114"
+django-markdownify = "^0.9.5"
 
 [tool.poetry.group.dev]
 


### PR DESCRIPTION
Install django-markdownify. This commit is based off of commit e669acf1a9899083b4446504f014c18e8c699691

This fixes the following Nix build issue caused by poetry not supporting the new pyproject.toml syntax:

```
python3.12-markdown>   configuration error: `project.license` must be valid exactly by one
python3.12-markdown>       - keys:
python3.12-markdown>           'file': {type: string}
python3.12-markdown>         required: ['file']
python3.12-markdown>       - keys:
python3.12-markdown>           'text': {type: string}
python3.12-markdown>         required: ['text']
python3.12-markdown>   DESCRIPTION:
python3.12-markdown>       `Project license <https://peps.python.org/pep-0621/#license>`_.
python3.12-markdown>   GIVEN VALUE:
python3.12-markdown>       "BSD-3-Clause"
```

The solution is to replace the markdown package with the Nix distributed markdown package. This is a workaround and replacing poetry2nix with a better system is the better option for the future.