### PR TITLE
FE: Fix dashboard page shortcut key function

### DIFF
--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -9,6 +9,9 @@ type KeyboardKey = "Escape" | "Enter" | "j" | "k" | "h" | "l";
 // key
 function filterKey(key: KeyboardKey, fn: KeyCallback) {
     return (e: KeyboardEvent) => {
+        if (document.activeElement?.nodeName === "INPUT") {
+            return;
+        }
         if (e.key !== key) {
             return;
         }


### PR DESCRIPTION
### Issue
It was not possible to input some key on dashboard page. For example, when you type "l" at the text field to create a new label, the browser moves its focus to the task on the left side.

### Fixed
Avoid executing an short cut event if the browser is focused on INPUT element